### PR TITLE
Fixes #88

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,16 +73,17 @@ Available:
 
 ## <a name='Configuration'></a>Configuration
 
-| Environment                        | Helm                             | CLI                                | Default       |
-|------------------------------------|----------------------------------|------------------------------------|---------------|
-| PORT                               | service.port                     | --port                             | `80`          |
-| LOGS__IGNORE__PING                 | application.logs.ignore.ping     | --logs:ignore:ping                 | `false`       |
-| ENABLE__HOST                       | application.enable.host          | --enable:host                      | `true`        |
-| ENABLE__HTTP                       | application.enable.http          | --enable:http                      | `true`        |
-| ENABLE__REQUEST                    | application.enable.request       | --enable:request                   | `true`        |
-| ENABLE__HEADER                     | application.enable.header        | --enable:header                    | `true`        |
-| ENABLE__ENVIRONMENT                | application.enable.environment   | --enable:environment               | `true`        |
-| ENABLE__FILE                       | application.enable.file          | --enable:file                      | `true`        |
+| Environment         | Helm                           | CLI                  | Default       |
+|---------------------|--------------------------------|----------------------|---------------|
+| PORT                | service.port                   | --port               | `80`          |
+| LOGS__IGNORE__PING  | application.logs.ignore.ping   | --logs:ignore:ping   | `false`       |
+| ENABLE__HOST        | application.enable.host        | --enable:host        | `true`        |
+| ENABLE__HTTP        | application.enable.http        | --enable:http        | `true`        |
+| ENABLE__REQUEST     | application.enable.request     | --enable:request     | `true`        |
+| ENABLE__COOKIES     | application.enable.cookies     | --enable:cookies     | `true`        |
+| ENABLE__HEADER      | application.enable.header      | --enable:header      | `true`        |
+| ENABLE__ENVIRONMENT | application.enable.environment | --enable:environment | `true`        |
+| ENABLE__FILE        | application.enable.file        | --enable:file        | `true`        |
 
 ## <a name='UseEcho-Server'></a>Use Echo-Server
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "echo-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "echo-server",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "GPL-3.0",
       "dependencies": {
         "body-parser": "^1.x.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "echo-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Kubernetes Echo Server",
   "main": "./src/app.js",
   "scripts": {

--- a/src/global.json
+++ b/src/global.json
@@ -18,6 +18,7 @@
         "host": true,
         "http": true,
         "request": true,
+        "cookies": true,
         "environment": true,
         "file": true,
         "header": true

--- a/src/response/request.js
+++ b/src/response/request.js
@@ -1,9 +1,24 @@
 const config = require('../nconf');
 
-module.exports = (req) => config.get('enable:request') ? {
-    params: req.params,
-    query: req.query,
-    cookies: req.cookies,
-    body: req.body,
-    headers: req.headers
-} : undefined;
+module.exports = (req) => {
+  if (config.get('enable:request')) {
+      if (config.get('enable:cookies')) {
+          return {
+              params: req.params,
+              query: req.query,
+              cookies: req.cookies,
+              body: req.body,
+              headers: req.headers
+          }
+      } else {
+          return {
+              params: req.params,
+              query: req.query,
+              body: req.body,
+              headers: req.headers
+          }
+      }
+  } else {
+      return undefined
+  }
+}

--- a/src/response/request.js
+++ b/src/response/request.js
@@ -11,6 +11,7 @@ module.exports = (req) => {
               headers: req.headers
           }
       } else {
+          delete req.headers["cookie"];
           return {
               params: req.params,
               query: req.query,


### PR DESCRIPTION
## Description

This adds a newer feature flag `--enable:cookies` which is true by default. It allows you to not echo cookies if you so wish.

## Related Issue

Trying to fix #88.

## Motivation and Context

Echoing cookies could potentially enable XSS attacks. If an echo service is run under a domain that exposes an XSS issue. Sensitive cookies could get exposed.

## How Has This Been Tested

Running it locally and testing with `curl --cookie "mycookie=safe" http://localhost:8080` didn't reveal the cookie.

It is however still in the header output. So the feature is not yet complete.

## Types of changes

- [ ] 🐛Bug fix (non-breaking change which fixes an issue)
- [x] 🚀New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
