### PR TITLE
feat: Graceful shutdown on SIGTERM signal

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,14 @@ const http = require('http')
   , server = http.createServer(app)
   , bodyParser = require('body-parser');
 
+// Signal handling
+process.on('SIGTERM', () => {
+  console.log('Received SIGTERM signal. Gracefully stopping web server.');
+  server.close(() => {
+    console.log('Server stopped sucessfully.');
+  });
+});
+
 // Configuration
 app.disable('x-powered-by');
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This changes will trigger a graceful shutdown when receiving a SIGTERM signal.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->
fixes #96 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

When this app runs in a Kubernetes context (for eg.) and someone asks to stop the pod, Kubernetes will first send a SIGTERM signal to ask the app to stop by itself. If the app does not exit by itself, it waits for a timeout (`terminationGracePeriod`, defaults to 30s) before sending a SIGKILL signal that asks the system to stop the process forcibly.  See https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-terminating-with-grace.

This change will make the app stop by itself as soon as the SIGTERM signal is received.

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not tested at the moment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] 🐛Bug fix (non-breaking change which fixes an issue)
- [x] 🚀New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
