### PR TITLE
Support Multiple custom headers and support Duplicate headers with different values

### DIFF
--- a/src/middlewares/customHttpHeadersMiddleware.js
+++ b/src/middlewares/customHttpHeadersMiddleware.js
@@ -2,18 +2,27 @@ const config = require('../nconf');
 
 const setupHttpHeaders = (value, res) => {
   if (value) {
-    var elements = value.split(', ');
+    // Split by ";" instead of "," to allow commas inside header values
+    // Adding trim to avoid spaces and make code resilient
+    const elements = value.split(';');
     elements.forEach(customHeader => {
-      var array = customHeader.split(':');
-      // Using append for multiple headers with same key like set-cookie header
-      // Adding trim to avoid spaces and make code resilient
-      res.append(array[0].trim(), array.slice(1).join(':').trim());
+      // Skip empty headers
+      if (!customHeader.trim()) return; 
+
+      const array = customHeader.split(':');
+      const key = array[0].trim();
+      const val = array.slice(1).join(':').trim();
+
+      if (key) {
+        // append preserves duplicates (e.g. multiple Set-Cookie headers)
+        res.append(key, val); 
+      }
     });
   }
-}
+};
 
 module.exports = (req, res, next) => {
-  if (config.get('enable:header')) { 
+  if (config.get('enable:header')) {
     try {
       setupHttpHeaders(req.headers[config.get('commands:httpHeaders:header')], res);
       setupHttpHeaders(req.query[config.get('commands:httpHeaders:query')], res);
@@ -23,4 +32,4 @@ module.exports = (req, res, next) => {
   } else {
     next();
   }
-}
+};

--- a/src/middlewares/customHttpHeadersMiddleware.js
+++ b/src/middlewares/customHttpHeadersMiddleware.js
@@ -5,7 +5,9 @@ const setupHttpHeaders = (value, res) => {
     var elements = value.split(', ');
     elements.forEach(customHeader => {
       var array = customHeader.split(':');
-      res.header(array[0], array.slice(1, array.length).join(':'));
+      // Using append for multiple headers with same key like set-cookie header
+      // Adding trim to avoid spaces and make code resilient
+      res.append(array[0].trim(), array.slice(1).join(':').trim());
     });
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR updates the custom header middleware to:
- Use `;` as the delimiter when parsing multiple headers from `X-ECHO-HEADER`, instead of `,`, to avoid breaking headers like `Cache-Control` that legitimately contain commas in their values.
- Switch from `res.header()` to `res.append()` so that headers that allow multiple values (e.g. `Set-Cookie`) are preserved instead of overwritten.
- Improve parsing by trimming whitespace and allowing empty header values (e.g. `abc:`), while skipping invalid headers with no key.

## Related Issue
<!--- Please link to the issue here -->
Fixes #148 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Correctly handle headers that contain comma-delimited values.
- Support multiple `Set-Cookie` headers, which previously were overwritten.
- Improve resilience against malformed input (`;` at end, no value, etc.).

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
Tested manually with `curl` against the echo server:

```bash
curl "https://.../echoserver" \
  -H 'X-ECHO-HEADER: Cache-Control: max-age=300, public; One: 1; Set-Cookie: a=1; Set-Cookie: b=2'
```

Observed correct response headers:

```
Cache-Control: max-age=300, public
One: 1
Set-Cookie: a=1
Set-Cookie: b=2
```

Also tested edge cases:

abc: → header with empty value is preserved.

abc:None → value "None" is preserved.

Extra ; → ignored safely.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] 🐛Bug fix (non-breaking change which fixes an issue)
- [x] 🚀New feature (non-breaking change which adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

